### PR TITLE
Correct a mistake in a warning message about measure name

### DIFF
--- a/lib/bcl/component_methods.rb
+++ b/lib/bcl/component_methods.rb
@@ -366,7 +366,7 @@ module BCL
 
       puts '[WARNING] {Validation} Could not find measure description in measure.'  unless h[:description]
       puts '[WARNING] {Validation} Could not find modeler description in measure.'  unless h[:modeler_description]
-      puts '[WARNING] {Validation} Could not find measure name method in measure.'  unless h[:name_from_measure]
+      puts '[WARNING] {Validation} Could not find measure name method in measure.'  unless h[:display_name_from_measure]
 
       # check the naming conventions
       if h[:display_name_from_measure]


### PR DESCRIPTION
The variable :name_from_measure appears to have been changed to :display_name_from_measure, but the warning check was never updated.  This means the warning gets thrown on every measure in a directory.