### PR TITLE
add ruby 3.2 requirement

### DIFF
--- a/bcl.gemspec
+++ b/bcl.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '~> 3.2'
+
   spec.add_dependency 'builder', '3.2.4'
   spec.add_dependency 'faraday', '~> 1.0.1'
   spec.add_dependency 'minitar', '~> 0.9'
@@ -41,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'yamler', '0.1.0'
   spec.add_dependency 'zliby', '0.0.5'
 
+  spec.add_development_dependency 'bundler', '>= 2.5.5'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
 end


### PR DESCRIPTION
added ruby 3.2 requirement
added bundler development dependency to be consistent with the other openstudio gems